### PR TITLE
correction to headers cookie string, some cleaning

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,14 +51,11 @@ class PythonAnywhereTool:
         headers = {
             "Host": "www.pythonanywhere.com",
             "Referer": "https://www.pythonanywhere.com/user/manuelseromenho/webapps/",
-            "X-CSRFToken": self.csrftoken,
-            "X-Requested-With": "XMLHttpRequest",
-            "Origin": "https://www.pythonanywhere.com",
             "Cookie": (
-                f"web_app_tab_type={self.web_app_tab_type};"
-                "cookie_warning_seen=True;"
-                "csrftoken={self.csrftoken};"
-                "sessionid={self.session_id};"
+                f"web_app_tab_type={self.web_app_tab_type}; "
+                f"cookie_warning_seen=True;"
+                f"csrftoken={self.csrftoken};"
+                f"sessionid={self.session_id};"
             ),
             "Content-Type": "application/x-www-form-urlencoded",
         }


### PR DESCRIPTION
```
"Cookie": (
                f"web_app_tab_type={self.web_app_tab_type}; "
                f"cookie_warning_seen=True;"
                f"csrftoken={self.csrftoken};"
                f"sessionid={self.session_id};"
            ),
```

Must be careful with Pycharm IDE, while giving paragraphs with an old version from 2021 of Pycharm, it would not introduce the f literal in the extra lines. Basically the cookie string wasn't being formed correctly. And again must be careful with Pycharm IDE. 